### PR TITLE
Handle several types of file objects

### DIFF
--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -79,7 +79,8 @@ class MimeMagic
   # This is a slow operation.
   def self.by_magic(io)
     if !(io.respond_to?(:seek) && io.respond_to?(:read))
-      io = StringIO.new(io.to_s, 'rb:binary')
+      str = io.respond_to?(:read) ? io.read : io.to_s
+      io = StringIO.new(str, 'rb:binary')
     end
     mime = MAGIC.find {|type, matches| magic_match(io, matches) }
     mime && new(mime[0])

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -82,4 +82,20 @@ describe 'MimeMagic' do
     MimeMagic.by_magic('Y MAGICTEST').should.equal 'application/mimemagic-test'
     MimeMagic.by_magic('Z MAGICTEST').should.equal nil
   end
+
+  it 'should handle different file objects' do
+    MimeMagic.add('application/mimemagic-test', :magic => [[0, 'MAGICTEST']])
+    class ReadableObj
+      def read
+        'MAGICTEST'
+      end
+    end
+    MimeMagic.by_magic(ReadableObj.new).should.equal 'application/mimemagic-test'
+    class StringableObject
+      def to_s
+        'MAGICTEST'
+      end
+    end
+    MimeMagic.by_magic(StringableObject.new).should.equal 'application/mimemagic-test'
+  end
 end


### PR DESCRIPTION
If the object given to `by_magic` doesn't support `seek`, it will first
attempt to `read` the object, and failing that fall back to `to_s`. This
supports `ActionDispatch::Http::UploadedFile` objects.
