### PR TITLE
Ruby 2.0 compatibility

### DIFF
--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -2,6 +2,17 @@ require 'mimemagic/tables'
 require 'mimemagic/version'
 require 'stringio'
 
+#
+# Add a stubbed force_encoding for ruby 1.8
+#
+if ! "".respond_to?(:force_encoding)
+  class String
+    def force_encoding(enc)
+      self
+    end
+  end
+end
+
 # Mime type detection
 class MimeMagic
   attr_reader :type, :mediatype, :subtype


### PR DESCRIPTION
Currently MimeMagic.by_magic isn't working in Ruby 2.0, I believe for problems which are described here: http://stackoverflow.com/questions/15843684/binary-string-literals-in-ruby-2-0

This PR should address the problem, while maintaining compatibility with ruby 1.9 and ruby 1.8.
