### PR TITLE
Handle .docx, .xlsx, and .pptx with extra magic

### DIFF
--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -1,5 +1,6 @@
 require 'mimemagic/tables'
 require 'mimemagic/version'
+require 'mimemagic/extra_magic'
 
 # Mime type detection
 class MimeMagic

--- a/lib/mimemagic/extra_magic.rb
+++ b/lib/mimemagic/extra_magic.rb
@@ -1,0 +1,13 @@
+class MimeMagic
+  # The freedesktop.org magic tables don't handle .xlsx, .pptx, or
+  # .docx files. These magic ranges are too large for them to accept
+  # (https://bugs.freedesktop.org/show_bug.cgi?id=78797).
+  #
+  EXTRA_MAGIC = [
+    ['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0..2000, 'ppt/']]],
+    ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', [[0..2000, 'xl/']]],
+    ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', [[0..2000, 'word/']]]
+  ]
+
+  MAGIC = EXTRA_MAGIC + AUTO_MAGIC
+end

--- a/lib/mimemagic/tables.rb
+++ b/lib/mimemagic/tables.rb
@@ -1422,7 +1422,7 @@ class MimeMagic
   }
   # @private
   # :nodoc:
-  MAGIC = [
+  AUTO_MAGIC = [
     ['application/vnd.stardivision.writer', [[2089, 'StarWriter']]],
     ['application/x-docbook+xml', [[0, '<?xml', [[0..100, '-//OASIS//DTD DocBook XML'], [0..100, '-//KDE//DTD DocBook XML']]]]],
     ['image/x-eps', [[0, '%!', [[15, 'EPS']]], [0, "\004%!", [[16, 'EPS']]], [0, "\305\320\323\306"]]],

--- a/script/generate-mime.rb
+++ b/script/generate-mime.rb
@@ -112,7 +112,7 @@ end
 puts "  }"
 puts "  # @private"
 puts "  # :nodoc:"
-puts "  MAGIC = ["
+puts "  AUTO_MAGIC = ["
 magics.each do |priority, type, matches|
   puts "    ['#{type}', #{matches.inspect}],"
 end


### PR DESCRIPTION
The freedesktop magic doesn't work for the Office 2007+ files, it
detects them all as application/zip. I have magic which detects them,
but it requires looking at 2,000 byte ranges, too much for their
project (which has to support things like file browsers). Since you
already warn that `by_magic` is slow, it'd be nice to support it here
at least.

This would allow the paperclip project to use mimemagic and stop
relying on the `file` binary:

  - https://github.com/thoughtbot/paperclip/issues/1530#issuecomment-43375497

Support is through a new EXTRA_MAGIC constant in extra_magic.rb, and
renaming the old MAGIC to AUTO_MAGIC. This way you can continue to
auto-generate tables.rb from the xml while layering new extra magic on
top. Fixes #15 