### PR TITLE
Extend the range we search for MS files

### DIFF
--- a/lib/mimemagic/overlay.rb
+++ b/lib/mimemagic/overlay.rb
@@ -1,7 +1,7 @@
 # Extra magic
 
-[['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0..2000, 'ppt/']]],
- ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', [[0..2000, 'xl/']]],
- ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', [[0..2000, 'word/']]]].each do |magic|
+[['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0..5000, 'ppt/']]],
+ ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', [[0..5000, 'xl/']]],
+ ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', [[0..5000, 'word/']]]].each do |magic|
   MimeMagic.add(magic[0], magic: magic[1])
 end


### PR DESCRIPTION
Sometimes the first instance of the word/ or ppt/ is not in the first 2000 bytes - 5000 should cover it.