### PR TITLE
avoid loose matching on msoffice formats in overlay.rb

### DIFF
--- a/lib/mimemagic/overlay.rb
+++ b/lib/mimemagic/overlay.rb
@@ -1,7 +1,7 @@
 # Extra magic
 
-[['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0..5000, 'ppt/']]],
- ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', [[0..5000, 'xl/']]],
- ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', [[0..5000, 'word/']]]].each do |magic|
+[['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0, "PK\003\004", [[30, '[Content_Types].xml', [[0..5000, 'ppt/']]]]]]],
+ ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', [[0, "PK\003\004", [[30, '[Content_Types].xml', [[0..5000, 'xl/']]]]]]],
+ ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', [[0, "PK\003\004", [[30, '[Content_Types].xml', [[0..5000, 'word/']]]]]]]].each do |magic|
   MimeMagic.add(magic[0], magic: magic[1])
 end


### PR DESCRIPTION
I noticed Paperclip has lately been failing with a large number of false positives.  This is due to the very loose magic patterns in overlay.rb. We should at least check that the file is in zip format before concluding that any file with "xl/" in the first 5000 bytes is an excel file! I've also thrown in a check for "[Content_Types.xml]" which always seems to be present in the office files I have checked.