### PR TITLE
Add support for returning all possible mime types by magic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
+  - 2.3.0
   - ruby-head
   - jruby-19mode
   - rbx
+before_install:
+  - gem install bundler # the default bundler version on travis is very old and causes 1.9.3 build issues
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -76,17 +76,14 @@ class MimeMagic
   # Lookup mime type by magic content analysis.
   # This is a slow operation.
   def self.by_magic(io)
-    mime =
-      unless io.respond_to?(:seek) && io.respond_to?(:read)
-        str = io.respond_to?(:read) ? io.read : io.to_s
-        str = str.force_encoding(Encoding::BINARY) if str.respond_to? :force_encoding
-        MAGIC.find {|type, matches| magic_match_str(str, matches) }
-      else
-        io.binmode
-        io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
-        MAGIC.find {|type, matches| magic_match_io(io, matches) }
-      end
+    mime = magic_match(io, :find)
     mime && new(mime[0])
+  end
+
+  # Lookup all mime types by magic content analysis.
+  # This is a slower operation.
+  def self.all_by_magic(io)
+    magic_match(io, :select).map { |mime| new(mime[0]) }
   end
 
   # Return type as string
@@ -107,6 +104,19 @@ class MimeMagic
 
   def self.child?(child, parent)
     child == parent || TYPES.key?(child) && TYPES[child][1].any? {|p| child?(p, parent) }
+  end
+
+  def self.magic_match(io, method)
+    mime_or_mimes = if io.respond_to?(:seek) && io.respond_to?(:read)
+                      io.binmode
+                      io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
+                      MAGIC.send(method) { |type, matches| magic_match_io(io, matches) }
+                    else
+                      str = io.respond_to?(:read) ? io.read : io.to_s
+                      str = str.force_encoding(Encoding::BINARY) if str.respond_to?(:force_encoding)
+                      MAGIC.send(method) { |type, matches| magic_match_str(str, matches) }
+                    end
+    method == :find ? [mime_or_mimes] : mime_or_mimes
   end
 
   def self.magic_match_io(io, matches)
@@ -137,5 +147,5 @@ class MimeMagic
     end
   end
 
-  private_class_method :magic_match_io, :magic_match_str
+  private_class_method :magic_match, :magic_match_io, :magic_match_str
 end

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -107,16 +107,15 @@ class MimeMagic
   end
 
   def self.magic_match(io, method)
-    mime_or_mimes = if io.respond_to?(:seek) && io.respond_to?(:read)
-                      io.binmode
-                      io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
-                      MAGIC.send(method) { |type, matches| magic_match_io(io, matches) }
-                    else
-                      str = io.respond_to?(:read) ? io.read : io.to_s
-                      str = str.force_encoding(Encoding::BINARY) if str.respond_to?(:force_encoding)
-                      MAGIC.send(method) { |type, matches| magic_match_str(str, matches) }
-                    end
-    method == :find ? [mime_or_mimes] : mime_or_mimes
+    if io.respond_to?(:seek) && io.respond_to?(:read)
+      io.binmode
+      io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
+      MAGIC.send(method) { |type, matches| magic_match_io(io, matches) }
+    else
+      str = io.respond_to?(:read) ? io.read : io.to_s
+      str = str.force_encoding(Encoding::BINARY) if str.respond_to?(:force_encoding)
+      MAGIC.send(method) { |type, matches| magic_match_str(str, matches) }
+    end
   end
 
   def self.magic_match_io(io, matches)

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -65,6 +65,13 @@ describe 'MimeMagic' do
     end
   end
 
+  it 'should recognize all by magic' do
+    require 'mimemagic/overlay'
+    file = 'test/files/application.vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    mimes = %w[application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/zip]
+    MimeMagic.all_by_magic(File.read(file)).map(&:type).should.equal mimes
+  end
+
   it 'should have add' do
     MimeMagic.add('application/mimemagic-test',
                   extensions: %w(ext1 ext2),


### PR DESCRIPTION
Provide a convenient way to get all possible mime types by magic, and not just the first mime type.  This will allow users to check against a list of possible mime types in some situations where the file extension may indicate one thing, but the file contents indicate it could be several different things.  For example, in issue #36 it would be nice to be able to determine the mime type based on both the file extension and the file contents.