### PR TITLE
Support IO-like objects efficiently

### DIFF
--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -1,6 +1,7 @@
 require 'bacon'
 require 'mimemagic'
 require 'stringio'
+require 'forwardable'
 
 describe 'MimeMagic' do
   it 'should have type, mediatype and subtype' do
@@ -116,12 +117,15 @@ describe 'MimeMagic' do
 
   it 'should handle different file objects' do
     MimeMagic.add('application/mimemagic-test', magic: [[0, 'MAGICTEST']])
-    class ReadableObj
-      def read
-        'MAGICTEST'
+    class IOObject
+      def initialize
+        @io = StringIO.new('MAGICTEST')
       end
+
+      extend Forwardable
+      delegate [:read, :size, :rewind, :eof?, :close] => :@io
     end
-    MimeMagic.by_magic(ReadableObj.new).should.equal 'application/mimemagic-test'
+    MimeMagic.by_magic(IOObject.new).should.equal 'application/mimemagic-test'
     class StringableObject
       def to_s
         'MAGICTEST'


### PR DESCRIPTION
[Shrine](https://github.com/janko-m/shrine) works with the abstraction of IO-like objects. For an object to be "IO-like" it proved to be enough that it responds to five IO methods: `#read`, `#size`, `#rewind`, `#eof?`, and `#close`.

However, MimeMagic expects the IO object to also respond to `#seek` (and also `#binmode`). If it doesn't respond to `#seek`, MimeMagic will currently read the whole file into memory. This will cause problems with large files and [remote files](https://github.com/janko-m/down#streaming).

Fortunately, the functionality of `io.seek(n)` can actually be produced using only the five methods mentioned above:

```rb
io.rewind
io.read(n)
```

This PR switches MimeMagic to use only these methods, allowing more generic IO-like objects.