### PR TITLE
Set available rbx name on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.5
   - ruby-head
   - jruby-19mode
-  - rbx
+  - rbx-3
 before_install:
   - gem install bundler # the default bundler version on travis is very old and causes 1.9.3 build issues
 matrix:


### PR DESCRIPTION
Because "rbx" does not exist in Travis.

Maybe this PR fixes below error about "rbx".
https://travis-ci.org/minad/mimemagic/builds/373946566
