### PR TITLE
Change testing framework from bacon to minitest.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
+require 'rake/testtask'
+
 task :default => %w(test)
 
-desc 'Run tests with bacon'
-task :test => FileList['test/*_test.rb'] do |t|
-  sh "bacon -q -Ilib:test #{t.prerequisites.join(' ')}"
+desc 'Run tests with minitest'
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.pattern = 'test/*_test.rb'
 end
 
 desc 'Generate mime tables'

--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/minad/mimemagic'
   s.license = 'MIT'
 
-  s.add_development_dependency('bacon')
+  s.add_development_dependency('minitest', '~> 5.11')
   s.add_development_dependency('rake')
 end

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -1,136 +1,155 @@
-require 'bacon'
+require 'minitest/autorun'
 require 'mimemagic'
 require 'stringio'
 require 'forwardable'
 
-describe 'MimeMagic' do
-  it 'should have type, mediatype and subtype' do
-    MimeMagic.new('text/html').type.should.equal 'text/html'
-    MimeMagic.new('text/html').mediatype.should.equal 'text'
-    MimeMagic.new('text/html').subtype.should.equal 'html'
+class TestMimeMagic < Minitest::Test
+  # Do deep copy for constants of initial state.
+  INIT_EXTENSIONS = Marshal.load(Marshal.dump(MimeMagic::EXTENSIONS))
+  INIT_TYPES = Marshal.load(Marshal.dump(MimeMagic::TYPES))
+  INIT_MAGIC = Marshal.load(Marshal.dump(MimeMagic::MAGIC))
+
+  def setup
+    extentions = Marshal.load(Marshal.dump(INIT_EXTENSIONS))
+    types = Marshal.load(Marshal.dump(INIT_TYPES))
+    magic = Marshal.load(Marshal.dump(INIT_MAGIC))
+    MimeMagic.send(:remove_const, :EXTENSIONS) if MimeMagic.const_defined?(:EXTENSIONS)
+    MimeMagic.send(:remove_const, :TYPES) if MimeMagic.const_defined?(:TYPES)
+    MimeMagic.send(:remove_const, :MAGIC) if MimeMagic.const_defined?(:MAGIC)
+    MimeMagic.const_set('EXTENSIONS', extentions)
+    MimeMagic.const_set('TYPES', types)
+    MimeMagic.const_set('MAGIC', magic)
   end
 
-  it 'should have mediatype helpers' do
-    MimeMagic.new('text/plain').should.be.text
-    MimeMagic.new('text/html').should.be.text
-    MimeMagic.new('application/xhtml+xml').should.be.text
-    MimeMagic.new('application/octet-stream').should.not.be.text
-    MimeMagic.new('image/png').should.not.be.text
-    MimeMagic.new('image/png').should.be.image
-    MimeMagic.new('video/ogg').should.be.video
-    MimeMagic.new('audio/mpeg').should.be.audio
+  def test_have_type_mediatype_and_subtype
+    assert_equal 'text/html', MimeMagic.new('text/html').type
+    assert_equal 'text', MimeMagic.new('text/html').mediatype
+    assert_equal 'html', MimeMagic.new('text/html').subtype
   end
 
-  it 'should have hierarchy' do
-    MimeMagic.new('text/html').should.be.child_of 'text/plain'
-    MimeMagic.new('text/x-java').should.be.child_of 'text/plain'
+  def test_have_mediatype_helpers
+    assert MimeMagic.new('text/plain').text?
+    assert MimeMagic.new('text/html').text?
+    assert MimeMagic.new('application/xhtml+xml').text?
+    refute MimeMagic.new('application/octet-stream').text?
+    refute MimeMagic.new('image/png').text?
+    assert MimeMagic.new('image/png').image?
+    assert MimeMagic.new('video/ogg').video?
+    assert MimeMagic.new('audio/mpeg').audio?
   end
 
-  it 'should have extensions' do
-    MimeMagic.new('text/html').extensions.should.equal %w(htm html)
+  def test_have_hierarchy
+    assert MimeMagic.new('text/html').child_of?('text/plain')
+    assert MimeMagic.new('text/x-java').child_of?('text/plain')
   end
 
-  it 'should have comment' do
-    MimeMagic.new('text/html').comment.should.equal 'HTML document'
+  def test_have_extensions
+    assert_equal %w(htm html), MimeMagic.new('text/html').extensions
   end
 
-  it 'should recognize extensions' do
-    MimeMagic.by_extension('.html').should.equal 'text/html'
-    MimeMagic.by_extension('html').should.equal 'text/html'
-    MimeMagic.by_extension(:html).should.equal 'text/html'
-    MimeMagic.by_extension('rb').should.equal 'application/x-ruby'
-    MimeMagic.by_extension('crazy').should.equal nil
-    MimeMagic.by_extension('').should.equal nil
+  def test_have_comment
+    assert_equal 'HTML document', MimeMagic.new('text/html').comment
   end
 
-  it 'should recognize by a path' do
-    MimeMagic.by_path('/adsjkfa/kajsdfkadsf/kajsdfjasdf.html').should.equal 'text/html'
-    MimeMagic.by_path('something.html').should.equal 'text/html'
-    MimeMagic.by_path('wtf.rb').should.equal 'application/x-ruby'
-    MimeMagic.by_path('where/am.html/crazy').should.equal nil
-    MimeMagic.by_path('').should.equal nil
+  def test_recognize_extensions
+    assert_equal 'text/html', MimeMagic.by_extension('.html').to_s
+    assert_equal 'text/html', MimeMagic.by_extension('html').to_s
+    assert_equal 'text/html', MimeMagic.by_extension(:html).to_s
+    assert_equal 'application/x-ruby', MimeMagic.by_extension('rb').to_s
+    assert_nil MimeMagic.by_extension('crazy')
+    assert_nil MimeMagic.by_extension('')
   end
 
-  it 'should recognize xlsx as zip without magic' do
+  def test_recognize_by_a_path
+    assert_equal 'text/html', MimeMagic.by_path('/adsjkfa/kajsdfkadsf/kajsdfjasdf.html').to_s
+    assert_equal 'text/html', MimeMagic.by_path('something.html').to_s
+    assert_equal 'application/x-ruby', MimeMagic.by_path('wtf.rb').to_s
+    assert_nil MimeMagic.by_path('where/am.html/crazy')
+    assert_nil MimeMagic.by_path('')
+  end
+
+  def test_recognize_xlsx_as_zip_without_magic
     file = "test/files/application.vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    MimeMagic.by_magic(File.read(file)).should.equal "application/zip"
-    MimeMagic.by_magic(File.open(file, 'rb')).should.equal "application/zip"
+    assert_equal "application/zip", MimeMagic.by_magic(File.read(file)).to_s
+    assert_equal "application/zip", MimeMagic.by_magic(File.open(file, 'rb')).to_s
   end
 
-  it 'should recognize by magic' do
-    require "mimemagic/overlay"
+  def test_recognize_by_magic
+    load "mimemagic/overlay.rb"
     Dir['test/files/*'].each do |file|
       mime = file[11..-1].sub('.', '/')
-      MimeMagic.by_magic(File.read(file)).should.equal mime
-      MimeMagic.by_magic(File.open(file, 'rb')).should.equal mime
+      assert_equal mime, MimeMagic.by_magic(File.read(file)).to_s
+      assert_equal mime, MimeMagic.by_magic(File.open(file, 'rb')).to_s
     end
   end
 
-  it 'should recognize all by magic' do
-    require 'mimemagic/overlay'
+  def test_recognize_all_by_magic
+    load 'mimemagic/overlay.rb'
     file = 'test/files/application.vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     mimes = %w[application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/zip]
-    MimeMagic.all_by_magic(File.read(file)).map(&:type).should.equal mimes
+    assert_equal mimes, MimeMagic.all_by_magic(File.read(file)).map(&:type)
   end
 
-  it 'should have add' do
+  def test_have_add
     MimeMagic.add('application/mimemagic-test',
                   extensions: %w(ext1 ext2),
                   parents: 'application/xml',
                   comment: 'Comment')
-    MimeMagic.by_extension('ext1').should.equal 'application/mimemagic-test'
-    MimeMagic.by_extension('ext2').should.equal 'application/mimemagic-test'
-    MimeMagic.by_extension('ext2').comment.should.equal 'Comment'
-    MimeMagic.new('application/mimemagic-test').extensions.should.equal %w(ext1 ext2)
-    MimeMagic.new('application/mimemagic-test').should.be.child_of 'text/plain'
+    assert_equal 'application/mimemagic-test', MimeMagic.by_extension('ext1').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_extension('ext2').to_s
+    assert_equal 'Comment', MimeMagic.by_extension('ext2').comment
+    assert_equal %w(ext1 ext2), MimeMagic.new('application/mimemagic-test').extensions
+    assert MimeMagic.new('application/mimemagic-test').child_of?('text/plain')
   end
 
-  it 'should process magic' do
+  def test_process_magic
     MimeMagic.add('application/mimemagic-test',
                   magic: [[0, 'MAGICTEST'], # MAGICTEST at position 0
                              [1, 'MAGICTEST'], # MAGICTEST at position 1
                              [9..12, 'MAGICTEST'], # MAGICTEST starting at position 9 to 12
                              [2, 'MAGICTEST', [[0, 'X'], [0, 'Y']]]]) # MAGICTEST at position 2 and (X at 0 or Y at 0)
 
-    MimeMagic.by_magic('MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic('XMAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(' MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic('123456789MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic('123456789ABMAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic('123456789ABCMAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic('123456789ABCDMAGICTEST').should.equal nil
-    MimeMagic.by_magic('X MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic('Y MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic('Z MAGICTEST').should.equal nil
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic('MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic('XMAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(' MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic('123456789MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic('123456789ABMAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic('123456789ABCMAGICTEST').to_s
+    assert_nil MimeMagic.by_magic('123456789ABCDMAGICTEST')
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic('X MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic('Y MAGICTEST').to_s
+    assert_nil MimeMagic.by_magic('Z MAGICTEST')
 
-    MimeMagic.by_magic(StringIO.new 'MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new 'XMAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new ' MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new '123456789MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new '123456789ABMAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new '123456789ABCMAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new '123456789ABCDMAGICTEST').should.equal nil
-    MimeMagic.by_magic(StringIO.new 'X MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new 'Y MAGICTEST').should.equal 'application/mimemagic-test'
-    MimeMagic.by_magic(StringIO.new 'Z MAGICTEST').should.equal nil
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new 'MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new 'XMAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new ' MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new '123456789MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new '123456789ABMAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new '123456789ABCMAGICTEST').to_s
+    assert_nil MimeMagic.by_magic(StringIO.new '123456789ABCDMAGICTEST')
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new 'X MAGICTEST').to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new 'Y MAGICTEST').to_s
+    assert_nil MimeMagic.by_magic(StringIO.new 'Z MAGICTEST')
   end
 
-  it 'should handle different file objects' do
-    MimeMagic.add('application/mimemagic-test', magic: [[0, 'MAGICTEST']])
-    class IOObject
-      def initialize
-        @io = StringIO.new('MAGICTEST')
-      end
+  class IOObject
+    def initialize
+      @io = StringIO.new('MAGICTEST')
+    end
 
-      extend Forwardable
-      delegate [:read, :size, :rewind, :eof?, :close] => :@io
+    extend Forwardable
+    delegate [:read, :size, :rewind, :eof?, :close] => :@io
+  end
+
+  class StringableObject
+    def to_s
+      'MAGICTEST'
     end
-    MimeMagic.by_magic(IOObject.new).should.equal 'application/mimemagic-test'
-    class StringableObject
-      def to_s
-        'MAGICTEST'
-      end
-    end
-    MimeMagic.by_magic(StringableObject.new).should.equal 'application/mimemagic-test'
+  end
+
+  def test_handle_different_file_objects
+    MimeMagic.add('application/mimemagic-test', magic: [[0, 'MAGICTEST']])
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(IOObject.new).to_s
+    assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringableObject.new).to_s
   end
 end


### PR DESCRIPTION
I changed the testing framework to `minitest`.
This fixes https://github.com/minad/mimemagic/issues/60 .

There is a issue.

Below test is randomly failed on my environment.

```
$ which ruby
/usr/local/ruby-2.5.1/bin/ruby

$ ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]

$ which bundle
/usr/local/ruby-2.5.1/bin/bundle

$ bundle -v
Bundler version 1.16.1

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * bundler (1.16.1)
  * mimemagic (0.3.2)
  * minitest (5.11.3)
  * rake (12.3.1)

$ bundle exec rake test
Run options: --seed 58090

# Running:

............F

Finished in 0.009302s, 1397.4866 runs/s, 7632.4267 assertions/s.

  1) Failure:
TestMimeMagic#test_recognize_xlsx_as_zip_without_magic [/home/jaruga/git/mimemagic/test/mimemagic_test.rb:56]:
--- expected
+++ actual
@@ -1 +1 @@
-#<MimeMagic:0xXXXXXX @type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", @mediatype="application", @subtype="vnd.openxmlformats-officedocument.spreadsheetml.sheet">
+"application/zip"


13 runs, 71 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)
/home/jaruga/git/mimemagic/vendor/bundle/ruby/2.5.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/ruby-2.5.1/bin/bundle:23:in `load'
/usr/local/ruby-2.5.1/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

But when running only the specified test case, it is always success.
```
$ bundle exec rake test TEST=test/mimemagic_test.rb TESTOPTS="--name=test_recognize_xlsx_as_zip_without_magic -v"
Run options: --name=test_recognize_xlsx_as_zip_without_magic -v --seed 22452

# Running:

TestMimeMagic#test_recognize_xlsx_as_zip_without_magic = 0.00 s = .

Finished in 0.002283s, 438.0704 runs/s, 876.1408 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

Do you know the reason?
I think in `MimeMagic magic_match` method,  the result and the logic of `MAGIC.send(method) { |type, matches| magic_match_io(io, matches, buffer) }` might be something wrong.

I also moved the class `IOObject` and `StringableObject` to outside of the testing method.
Because we can not define inside of the method.

