### PR TITLE
CI: rbx-3 in allow_failures, comment on Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ rvm:
   - jruby-19mode
   - rbx-3
 before_install:
-  - gem install bundler -v'< 2' # the default bundler version on travis is very old and causes 1.9.3 build issues
+  # 1. The pre-installed Bundler version on Travis is very old; causes 1.9.3 build issues
+  # 2. Bundler 2.0 is not supported by the whole matrix
+  - gem install bundler -v'< 2'
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: rbx-3


### PR DESCRIPTION
This PR is to keep the build green: demote Rubinius builds to allowed failures.

Update Comment on Bundler versions.