### PR TITLE
gemspec: Drop rubyforge_project directive

### DIFF
--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.require_paths = %w(lib)
 
-  s.rubyforge_project = s.name
   s.summary = 'Fast mime detection by extension or content'
   s.description = 'Fast mime detection by extension or content in pure ruby (Uses freedesktop.org.xml shared-mime-info database)'
   s.homepage = 'https://github.com/minad/mimemagic'


### PR DESCRIPTION
This directive has been removed without a replacement.