### PR TITLE
Frozen string literal

### DIFF
--- a/lib/mimemagic/overlay.rb
+++ b/lib/mimemagic/overlay.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Extra magic
 
 [['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0, "PK\003\004", [[0..5000, '[Content_Types].xml', [[0..5000, 'ppt/']]]]]]],

--- a/lib/mimemagic/tables.rb
+++ b/lib/mimemagic/tables.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+# frozen_string_literal: true
 # Generated from freedesktop.org.xml
 class MimeMagic
   # @private

--- a/script/generate-mime.rb
+++ b/script/generate-mime.rb
@@ -133,6 +133,7 @@ end
 magics = (common_magics.compact + magics).uniq
 
 puts "# -*- coding: binary -*-"
+puts "# frozen_string_literal: true"
 puts "# Generated from #{FILE}"
 puts "class MimeMagic"
 puts "  # @private"


### PR DESCRIPTION
After digging a bit in my project, I found that `mimemagic` used a lot of allocated memory that could be reduced by adding the `frozen_string_literal` pragma.

I launched `bundle exec derailed bundle:mem` from the `derailed_benchmarks` gem before and after the modifications, and `mimemagic` now uses half of the memory it used before.

We could add more memory optimisations to `tables.rb` (like, there are a lot of `%w()` that we can probably optimize, same goes for the very common mime types like `%w(text/plain)`), but it could make the file less readable.