### PR TITLE
Remove rubyforge_project

### DIFF
--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.require_paths = %w(lib)
 
-  s.rubyforge_project = s.name
   s.summary = 'Fast mime detection by extension or content'
   s.description = 'Fast mime detection by extension or content in pure ruby (Uses freedesktop.org.xml shared-mime-info database)'
   s.homepage = 'https://github.com/minad/mimemagic'


### PR DESCRIPTION
This is deprecated by rubygems:
```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.

Gem::Specification#rubyforge_project= called from /home/travis/build/sul-dlss/pre-assembly/vendor/bundle/ruby/2.5.0/specifications/mimemagic-0.3.3.gemspec:16.
```