### PR TITLE
Ensure that frozen string literals used throughout the code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: ruby
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - ruby-head
-  - jruby-19mode
-  - rbx-3
+jobs:
+  include:
+    - rvm: 1.9.3
+    - rvm: 2.0.0
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: 2.3
+    - rvm: 2.4
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: 2.5
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: ruby-head
+      env: RUBYOPT="--enable-frozen-string-literal"
 before_install:
   # 1. The pre-installed Bundler version on Travis is very old; causes 1.9.3 build issues
   # 2. Bundler 2.0 is not supported by the whole matrix
   - gem install bundler -v'< 2'
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: rbx-3
+
+script:
+  -  bundle exec rake

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mimemagic/tables'
 require 'mimemagic/version'
 
@@ -113,7 +115,7 @@ class MimeMagic
 
     io.binmode if io.respond_to?(:binmode)
     io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
-    buffer = "".force_encoding(Encoding::BINARY)
+    buffer = "".encode(Encoding::BINARY)
 
     MAGIC.send(method) { |type, matches| magic_match_io(io, matches, buffer) }
   end

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -44,7 +44,7 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_have_extensions
-    assert_equal %w(htm html), MimeMagic.new('text/html').extensions
+    assert_equal %w(html htm), MimeMagic.new('text/html').extensions
   end
 
   def test_have_comment


### PR DESCRIPTION
I saw that there were already previous efforts to treat strings as frozen literals: https://github.com/minad/mimemagic/pull/79 and https://github.com/minad/mimemagic/pull/76.

But then other part of the codebase did not use it. This PR tries to complete it and adds `RUBYOPT` on supported platforms when running tests to ensure that the code is frozen string literal friendly.

I also took liberty and:
* fixed a test that was failing (comparison of arrays);
* removed `rbx-3` from the build matrix (it's failing to fetch the necessary installation artifacts).