### PR TITLE
Ensure that the array is sorted before asserting

### DIFF
--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -44,7 +44,7 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_have_extensions
-    assert_equal %w(htm html), MimeMagic.new('text/html').extensions
+    assert_equal %w(htm html).sort, MimeMagic.new('text/html').extensions.sort
   end
 
   def test_have_comment


### PR DESCRIPTION
For some reason, on my machine (`ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin19]`) this test fails, as the order in the array do not match. As I understand the order is not important for the working code, so, I updated the test to ensure that the test performs consistent across platforms.