### PR TITLE
sort lists similarly in test_have_extenstions

### DIFF
--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -44,7 +44,7 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_have_extensions
-    assert_equal %w(html htm), MimeMagic.new('text/html').extensions
+    assert_equal ["html", "htm"].sort, MimeMagic.new('text/html').extensions.sort
   end
 
   def test_have_comment


### PR DESCRIPTION
Depending on your locale, the extensions get output in one order or the other, and it might be not the one given in the current left-hand side.
This happens in Debian, when the package containing this gem is build, as the 'C' .

This proposition is to use sorted lists on both sides.