### PR TITLE
Reduce gem package size

### DIFF
--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.date = Date.today.to_s
   s.email = ['mail@daniel-mendler.de']
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(test|script)/}) }
   s.require_paths = %w(lib)
 
   s.summary = 'Fast mime detection by extension or content'


### PR DESCRIPTION
This pull request reduces the gem package size.



Currently this gem is 2.5MB.

```bash
$ cd path/to/installed/dir/lib/ruby/gems/2.7.0/gems
$ du mimemagic-0.3.5/ --summarize -h
2.5M    mimemagic-0.3.5/
```


But it contains unnecessary files for the package users, which are under `tests/` and `script/` directory.
Especially `script/` directory is large, but it isn't necessary for the users.


So this pull request removes them from the package.
It reduces 2.3MB.


```bash
# after this pull request
$ cd path/to/installed/dir/lib/ruby/gems/2.7.0/gems
$ du mimemagic-0.3.5/ --summarize -h
184K    mimemagic-0.3.5/
```