### PR TITLE
Update Rakefile to fix syntax error for ruby versions below 2.3

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -43,7 +43,7 @@ task :default do
   mkdir_p target_dir
 
   open("#{target_dir}/path.rb", "w") do |f|
-    f.print(<<~SOURCE
+    f.print(<<-SOURCE
       class MimeMagic
         DATABASE_PATH="#{mime_database_path}"
       end


### PR DESCRIPTION
We need the fix for ruby version 2.1 and 2.2. Also we need it in release 0.3.x to fulfil other gem's dependencies. For example paperclip 5.0.0 depends on mimemagic 0.3.0.
Hopefully it resolves #142