### PR TITLE
Fix MIT license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Authors
 LICENSE
 =======
 
-{file:LICENSE MIT}
+[MIT License](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
# Description
The README.md didn't correctly link to a MIT license. Fix that.