### PR TITLE
use XDG_DATA_DIRS to locate mime database

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -8,7 +8,7 @@ def locate_mime_database
     if ENV["XDG_DATA_DIRS"]
       ENV["XDG_DATA_DIRS"].
         split(':').
-        map { |data_dir| "#{data_dir}/mime/packages/freedesktop.org.xml" }
+        map { |data_dir| File.join(data_dir, "mime/packages/freedesktop.org.xml") }
     else
       []
     end) + [

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -3,7 +3,15 @@ require "rake/clean"
 
 def locate_mime_database
   possible_paths = [
-    (File.expand_path(ENV["FREEDESKTOP_MIME_TYPES_PATH"]) if ENV["FREEDESKTOP_MIME_TYPES_PATH"]),
+    (File.expand_path(ENV["FREEDESKTOP_MIME_TYPES_PATH"]) if ENV["FREEDESKTOP_MIME_TYPES_PATH"])
+  ] + (
+    if ENV["XDG_DATA_DIRS"]
+      ENV["XDG_DATA_DIRS"].
+        split(':').
+        map { |data_dir| "#{data_dir}/mime/packages/freedesktop.org.xml" }
+    else
+      []
+    end) + [
     "/usr/local/share/mime/packages/freedesktop.org.xml",
     "/opt/homebrew/share/mime/packages/freedesktop.org.xml",
     "/opt/local/share/mime/packages/freedesktop.org.xml",


### PR DESCRIPTION
I ran into issue https://github.com/mimemagicrb/mimemagic/issues/160. Not all operating systems are using /usr or /opt and `XDG_DATA_DIRS` was made to avoid hard-coding paths like /usr and /opt. This PR makes use of `XDG_DATA_DIRS` while still maintaining compatibility with systems that do not have `XDG_DATA_DIRS`.

On my system `XDG_DATA_DIRS` looks like:

```
$ echo $XDG_DATA_DIRS
/nix/store/mcxhdbhz0wqi3icx6lvc33iaggd02v6v-patchelf-0.12/share:/nix/store/wrkla3l0c3hg9m9bp5mvjj7z4xqv54wz-terminator-2.1.1/share:/nix/store/2bqip8j6v2hxpafpsaahfdq851i01nan-gsettings-desktop-schemas-40.0/share/gsettings-schemas/gsettings-desktop-schemas-40.0:/nix/store/fdjrhdgvhic14jg6llvm6vz2jvgnhfl6-gtk+3-3.24.27/share/gsettings-schemas/gtk+3-3.24.27:/nix/store/k75hslc3jrcb8y5rd92saxbxxkg2hb03-desktops/share:/home/bob.vanderlinden/.nix-profile/share:/etc/profiles/per-user/bob.vanderlinden/share:/nix/var/nix/profiles/default/share:/run/current-system/sw/share
```

Fixes https://github.com/mimemagicrb/mimemagic/issues/160
Possible replacement for https://github.com/mimemagicrb/mimemagic/pull/125
