### PR TITLE
whole schwack of new methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@ Gemfile.lock
 .yardoc
 doc/
 
+# mac junk
+._*
+
+# annoying emacs backups
+.\#*
+\#*\#
+
 vendor
 
 # don't include generated files

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -102,14 +102,21 @@ class MimeMagic
   end
 
   # Get MIME comment.
+  #
+  # @return [nil, String] the comment
+  #
   def comment
     TYPES.fetch(type, [nil, nil, nil])[2].to_s.dup
   end
 
-  # Look up MIME type by file extension. When `default` is true
+  # Look up MIME type by file extension. When `default` is true or a
+  # value, this method will always return a value.
   #
   # @param path [#to_s]
   # @param default [false, true, #to_s, MimeMagic] a default fallback type
+  #
+  # @return [nil, MimeMagic] the type, if found.
+  #
   def self.by_extension ext, default: false
     ext = ext.to_s.downcase.delete_prefix ?.
     default = coerce_default '', default
@@ -117,23 +124,27 @@ class MimeMagic
     mime ? new(mime) : default
   end
 
-  # Look up MIME type by filename.
+  # Look up MIME type by file path. When `default` is true or a value,
+  # this method will always return a value.
   #
-  # @param path [#to_s]
+  # @param path [#to_s] the file/path to check
   # @param default [false, true, #to_s, MimeMagic] a default fallback type
+  #
+  # @return [nil, MimeMagic] the type, if found.
   #
   def self.by_path path, default: false
     by_extension(File.extname(path), default: default)
   end
 
-  # Look up MIME type by magic content analysis.
+  # Look up MIME type by magic content analysis. When `default` is true or a
+  # value, this method will always return a value.
   #
   # @note This is a relatively slow operation.
   #
   # @param io [#read, #to_s] the IO/String-like object to check for magic
   # @param default [false, true, #to_s, MimeMagic] a default fallback type
   #
-  # @return [nil, MimeMagic] a matching type
+  # @return [nil, MimeMagic] a matching type, if found.
   #
   def self.by_magic io, default: false
     default = coerce_default io, default
@@ -141,7 +152,9 @@ class MimeMagic
     new mime.first
   end
 
-  # Return all matching MIME types by magic content analysis.
+  # Return all matching MIME types by magic content analysis. When
+  # `default` is true or a value, the result will never be empty.
+  #
   # @note This is a relatively slow operation.
   #
   # @param io [#read, #to_s] the IO/String-like object to check for magic

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -106,14 +106,15 @@ class MimeMagic
     TYPES.fetch(type, [nil, nil, nil])[2].to_s.dup
   end
 
-  # Look up MIME type by file extension
+  # Look up MIME type by file extension. When `default` is true
+  #
   # @param path [#to_s]
   # @param default [false, true, #to_s, MimeMagic] a default fallback type
   def self.by_extension ext, default: false
     ext = ext.to_s.downcase.delete_prefix ?.
-    default = coerce_default ext, default
+    default = coerce_default '', default
     mime = EXTENSIONS[ext]
-    mime && new(mime) || default
+    mime ? new(mime) : default
   end
 
   # Look up MIME type by filename.

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -205,7 +205,18 @@ class MimeMagic
   # @return [false, true] whether the two are equal.
   #
   def eql?(other)
-    type == self.class[other].canonical.type
+    # coerce the rhs
+    other = self.class[other]
+
+    # check for an exact match
+    ok = type.downcase == other.type.downcase
+    return ok if ok
+
+    # now canonicalize both sides and check
+    lhs = canonical
+    rhs = other.canonical
+
+    lhs && rhs && lhs.type == rhs.type
   end
 
   alias_method :==, :eql?

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -9,21 +9,26 @@ MimeMagic.parse_database
 
 # Mime type detection
 class MimeMagic
-  attr_reader :type, :mediatype, :subtype
+  attr_reader :type, :mediatype, :subtype, :params
 
   # Initialize a new MIME type by string
   def initialize(type)
-    @type = type.to_s.strip
-    @mediatype, @subtype = type.split('/', 2)
+    # chop off params
+    @type, *params = type.to_s.strip.split(/(?:\s*;\s*)+/)
+    @params = params.map { |x| x.split(/\s*=\s*/, 2) } unless params.empty?
+    @mediatype, @subtype = @type.split ?/, 2
   end
 
   # Syntactic sugar alias for constructor.
   #
-  # @param type [#to_s] a string-like object representing a MIME type.
+  # @param type [#to_s] a string-like object representing a MIME type
+  #  or file extension.
   #
   # @return [MimeMagic] the instantiated object.
   #
   def self.[] type
+    type = type.to_s.downcase.strip
+    return by_extension type unless type.to_s.include? ?/
     new type
   end
 
@@ -39,14 +44,14 @@ class MimeMagic
   def self.add type,
       extensions: [], parents: [], magic: [], comment: nil, aliases: []
     type = type.to_s.strip.downcase
-    extensions = [options[:extensions]].flatten.compact
-    aliases = [options[:aliases] || []].flatten.compact
-    t = TYPES[type] = [extensions, [options[:parents]].flatten.compact,
-                   options[:comment], type, aliases]
+    extensions = [extensions].flatten.compact
+    aliases = [[aliases] || []].flatten.compact
+    t = TYPES[type] = [extensions, [parents].flatten.compact,
+                   comment, type, aliases]
     aliases.each { |a| TYPES[a] = t }
     extensions.each {|ext| EXTENSIONS[ext] = type }
 
-    MAGIC.unshift [type, options[:magic]] if options[:magic]
+    MAGIC.unshift [type, magic] if magic
 
     true # output is ignored
   end
@@ -79,11 +84,19 @@ class MimeMagic
   def video?; mediatype == 'video'; end
 
   # Returns true if type is child of parent type
+  #
+  # @param parent [#to_s] a candidate parent type
+  #
+  # @return [true, false] whether `self` is a child of `parent`
+  #
   def child_of?(parent)
     self.class.child?(type, parent)
   end
 
   # Get string list of file extensions.
+  #
+  # @return [Array<String>] associated file extensions.
+  #
   def extensions
     TYPES.fetch(type, [[]]).first.map { |e| e.to_s.dup }
   end
@@ -94,50 +107,100 @@ class MimeMagic
   end
 
   # Look up MIME type by file extension
-  def self.by_extension(ext)
-    ext  = ext.to_s.downcase.delete_prefix ?.
+  # @param path [#to_s]
+  # @param default [false, true, #to_s, MimeMagic] a default fallback type
+  def self.by_extension ext, default: false
+    ext = ext.to_s.downcase.delete_prefix ?.
+    default = coerce_default ext, default
     mime = EXTENSIONS[ext]
-    mime && new(mime)
+    mime && new(mime) || default
   end
 
-  # Look up MIME type by filename
-  def self.by_path(path)
-    by_extension(File.extname(path))
+  # Look up MIME type by filename.
+  #
+  # @param path [#to_s]
+  # @param default [false, true, #to_s, MimeMagic] a default fallback type
+  #
+  def self.by_path path, default: false
+    by_extension(File.extname(path), default: default)
   end
 
   # Look up MIME type by magic content analysis.
-  # This is a slow operation.
-  def self.by_magic(io, default: false)
+  #
+  # @note This is a relatively slow operation.
+  #
+  # @param io [#read, #to_s] the IO/String-like object to check for magic
+  # @param default [false, true, #to_s, MimeMagic] a default fallback type
+  #
+  # @return [nil, MimeMagic] a matching type
+  #
+  def self.by_magic io, default: false
     default = coerce_default io, default
     mime = magic_match(io, :find) or return default
-    new mime || default
+    new mime.first
   end
 
   # Return all matching MIME types by magic content analysis.
-  # This is a slower operation.
-  def self.all_by_magic(io, default: false)
+  # @note This is a relatively slow operation.
+  #
+  # @param io [#read, #to_s] the IO/String-like object to check for magic
+  # @param default [false, true, #to_s, MimeMagic] a default fallback type
+  #
+  # @return [Array<MimeMagic>] all matching types
+  #
+  def self.all_by_magic io, default: false
     default = coerce_default io, default
     out = magic_match(io, :select).map { |mime| new mime.first }
     out << default if out.empty? and default
     out
   end
 
+  # Return a diagnostic representation of the object.
+  #
+  # @return [String] a string representing the object.
+  #
+  def inspect
+    out = @type
+    out = [out, @params.map { |x| x.join ?= }].join ?; if
+      @params and !@params.empty?
+    %q[<%s "%s">] % [self.class, out]
+  end
+
   # Return the type as a string.
+  #
+  # @return [String] the type, as a string.
+  #
   def to_s
     type
   end
 
   # Compare the equality of the type with another (or plain string).
+  #
+  # @param other [#to_s] the other to teset
+  #
+  # @return [false, true] whether the two are equal.
+  #
   def eql?(other)
     type == other.to_s
   end
 
   alias_method :==, :eql?
 
+  # Return the object's (the underlying type string) hash.
+  #
+  # @return [Integer] the hash value.
+  #
   def hash
     type.hash
   end
 
+  # Returns true if type is child of parent type.
+  #
+  # @param child [#to_s] a candidate child type
+  # @param parent [#to_s] a candidate parent type
+  #
+  # @return [true, false] whether `self` is a child of `parent`
+  #
   def self.child?(child, parent)
     child == parent || TYPES.fetch(child, [nil, []])[1].any? do |p|
       child? p, parent
@@ -163,6 +226,34 @@ class MimeMagic
     new t[3]
   end
 
+  # Determine if the type is an alias.
+  #
+  # @return [false, true] whether the type is an alias.
+  #
+  def alias?
+    type != canonical.type
+  end
+
+  # Return the type's aliases.
+  #
+  # @return [Array<MimeMagic>] the aliases, if any.
+  #
+  def aliases
+    self.class.aliases type
+  end
+
+  # Return the type's aliases.
+  #
+  # @param type [#to_s] the type to check
+  #
+  # @return [Array<MimeMagic>] the aliases, if any.
+  #
+  def self.aliases type
+    TYPES.fetch(type.to_s.downcase, [nil, nil, nil, nil, []])[4].map do |t|
+      new t
+    end
+  end
+
   # Fetches the immediate parent types.
   #
   # @return [Array<MimeMagic>] the type's parents
@@ -172,9 +263,10 @@ class MimeMagic
       self.class.new x
     end
     # add this unless we're it
-    out << self.class.new('application/octet-stream') unless
-      [type.downcase, out.last].any? { |x| x == 'application/octet-stream' }
-    out
+    out << self.class.new('application/octet-stream') if
+      out.empty? and type.downcase != 'application/octet-stream'
+
+    out.uniq
   end
 
   # Fetches the entire inheritance hierarchy for the given MIME type.
@@ -187,53 +279,49 @@ class MimeMagic
 
   alias_method :ancestor_types, :lineage
 
-  # Determine if the type is an alias.
+  # Determine if the type is binary.
   #
-  def alias?
-    type != canonical.type
-  end
-
-  # Return the type's aliases.
+  # @return [true, false, nil] whether the input is binary (`nil` if
+  #  indeterminate).
   #
-  def aliases
-    self.class.aliases type
-  end
-
-  # Return the type's aliases.
-  #
-  def self.aliases type
-    TYPES.fetch(type.to_s.downcase, [nil, nil, nil, nil, []])[4].map do |t|
-      new t
-    end
+  def binary?
+    not lineage.include? 'text/plain'
   end
 
   # Determine if an input is binary.
   #
-  # @param thing [#to_s, #read]
+  # @param thing [#read, #to_s] the IO-like or String-like thing to
+  #  test; can also be a file name/path/extension or MIME type.
   #
-  # @return [true, false]
+  # @return [true, false, nil] whether the input is binary (`nil` if
+  #  indeterminate).
   #
   def self.binary? thing
-    sample = nil
+    sample = ''
 
     # get some stuff out of the IO or get a substring
-    if %i[seek tell read].all? { |m| thing.respond_to? m }
+    if thing.is_a? MimeMagic
+      return thing.binary?
+    elsif %i[seek tell read].all? { |m| thing.respond_to? m }
       pos = thing.tell
       thing.seek 0, 0
-      sample = thing.read 100
+      sample = thing.read 256
       thing.seek pos
     elsif thing.respond_to? :to_s
       str = thing.to_s
-      # if it contains a slash
+      # if it contains a slash it could be either a path or mimetype
       test = if str.include? ?/
                canonical(str) || by_extension(str.split(?.).last)
              else
                by_extension str.split(?.).last
              end
 
-      return test.lineage.include? 'text/plain' if test
+      return test.binary? if test
 
-      sample = str[0,100]
+      sample = str[0, 256]
+    else
+      # nil if we don't know what this thing is
+      return
     end
 
     # consider this to be 'binary' if empty
@@ -242,14 +330,26 @@ class MimeMagic
     /[\x0-\x8\xe-\x1f\x7f]/.match? sample.b
   end
 
+  # Return either `application/octet-stream` or `text/plain` depending
+  # on whether the thing is binary.
+  #
+  # @param thing [#read, #to_s] the thing (IO-like, String-like, MIME type,
+  #
+  # @return [MimeMagic] the default type
+  #
+  def self.default_type thing
+    new(binary?(thing) ? 'application/octet-stream' : 'text/plain')
+  end
+
   private
 
-  def self.coerce_default io, default
+  def self.coerce_default thing, default
     case default
     when nil, false then nil
+    when true then default_type thing
     when MimeMagic then default
     when String, -> x { x.respond_to? :to_s } then new default
-    else default_type io
+    else default_type thing
     end
   end
 

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -362,7 +362,7 @@ class MimeMagic
     elsif %i[seek tell read].all? { |m| thing.respond_to? m }
       pos = thing.tell
       thing.seek 0, 0
-      sample = thing.read 256
+      sample = thing.read(256).to_s # handle empty
       thing.seek pos
     elsif thing.respond_to? :to_s
       str = thing.to_s

--- a/lib/mimemagic.rb
+++ b/lib/mimemagic.rb
@@ -11,12 +11,16 @@ MimeMagic.parse_database
 class MimeMagic
   attr_reader :type, :mediatype, :subtype, :params
 
-  # Initialize a new MIME type by string
+  # Initialize a new MIME type by its string representation.
+  #
+  # @param type [#to_s] the type to parse.
+  #
   def initialize(type)
-    # chop off params
-    @type, *params = type.to_s.strip.split(/(?:\s*;\s*)+/)
+    @type, *params = type.to_s.strip.split(/(?:\s*;\s*)+/) # chop off params
+    @type.downcase! # normalize the case
+    # split parameter-value pairs if present
     @params = params.map { |x| x.split(/\s*=\s*/, 2) } unless params.empty?
-    @mediatype, @subtype = @type.split ?/, 2
+    @mediatype, @subtype = @type.split ?/, 2 # split major and minor
   end
 
   # Syntactic sugar alias for constructor. No-op if `type` is already
@@ -32,8 +36,10 @@ class MimeMagic
     return type if type.is_a? self
 
     # now we handle the string
-    type = type.to_s.downcase.strip
-    return by_extension type unless type.to_s.include? ?/
+    type = type.to_s.strip
+    return by_extension type unless type.include? ?/
+
+    # otherwise pass to constructor
     new type
   end
 
@@ -209,8 +215,7 @@ class MimeMagic
     other = self.class[other]
 
     # check for an exact match
-    ok = type.downcase == other.type.downcase
-    return ok if ok
+    return true if type == other.type
 
     # now canonicalize both sides and check
     lhs = canonical

--- a/lib/mimemagic/tables.rb
+++ b/lib/mimemagic/tables.rb
@@ -94,9 +94,8 @@ class MimeMagic
 
       unless exts.empty?
         exts.each { |x| extensions[x] = type unless extensions.include?(x) }
-        t = types[type] = [exts, subclass, comments[nil], type, aliases]
-        # also add the aliases XXX NO don't add them yet
-        # aliases.each { |a| types[a] = t }
+        types[type] = [exts, subclass, comments[nil], type, aliases]
+        # don't add the aliases yet; we do that below
       end
     end
 

--- a/lib/mimemagic/tables.rb
+++ b/lib/mimemagic/tables.rb
@@ -92,8 +92,9 @@ class MimeMagic
 
       aliases = (mime/'alias/@type').map { |a| a.value.downcase.strip.freeze }
 
+      # XXX uhh do we only use the type if it has a file extension??
       unless exts.empty?
-        exts.each { |x| extensions[x] = type unless extensions.include?(x) }
+        exts.each { |x| extensions[x] ||= type }
         types[type] = [exts, subclass, comments[nil], type, aliases]
         # don't add the aliases yet; we do that below
       end
@@ -153,7 +154,10 @@ class MimeMagic
       parents.sort!
       aliases.sort!
 
+      # we are copying it i guess
       t = TYPES[key] = [exts, parents, comment, canon, aliases].freeze
+
+      # now do the aliases oops they'll be out of order oh well
       aliases.each { |a| TYPES[a] = t }
     end
 

--- a/lib/mimemagic/tables.rb
+++ b/lib/mimemagic/tables.rb
@@ -80,17 +80,23 @@ class MimeMagic
       comments = Hash[*(mime/'comment').map {|comment| [comment['xml:lang'], comment.inner_text] }.flatten]
       type = mime['type']
       subclass = (mime/'sub-class-of').map{|x| x['type']}
-      exts = (mime/'glob').map{|x| x['pattern'] =~ /^\*\.([^\[\]]+)$/ ? $1.downcase : nil }.compact
+      exts = (mime/'glob').map do |x|
+        x['pattern'] =~ /^\*\.([^\[\]]+)$/ ? $1.downcase : nil
+      end.compact
+
       (mime/'magic').each do |magic|
         priority = magic['priority'].to_i
         matches = get_matches(magic)
         magics << [priority, type, matches]
       end
-      if !exts.empty?
-        exts.each{|x|
-          extensions[x] = type if !extensions.include?(x)
-        }
-        types[type] = [exts,subclass,comments[nil]]
+
+      aliases = (mime/'alias/@type').map { |a| a.value.downcase.strip.freeze }
+
+      unless exts.empty?
+        exts.each { |x| extensions[x] = type unless extensions.include?(x) }
+        t = types[type] = [exts, subclass, comments[nil], type, aliases]
+        # also add the aliases XXX NO don't add them yet
+        # aliases.each { |a| types[a] = t }
       end
     end
 
@@ -141,13 +147,17 @@ class MimeMagic
     extensions.keys.sort.each do |key|
       EXTENSIONS[key] = extensions[key]
     end
-    types.keys.sort.each do |key|
-      exts = types[key][0]
-      parents = types[key][1].sort
-      comment = types[key][2]
 
-      TYPES[key] = [exts, parents, comment]
+    types.keys.sort.each do |key|
+      exts, parents, comment, canon, aliases = *types[key]
+
+      parents.sort!
+      aliases.sort!
+
+      t = TYPES[key] = [exts, parents, comment, canon, aliases].freeze
+      aliases.each { |a| TYPES[a] = t }
     end
+
     magics.each do |priority, type, matches|
       MAGIC << [type, matches]
     end

--- a/lib/mimemagic/version.rb
+++ b/lib/mimemagic/version.rb
@@ -1,5 +1,5 @@
 class MimeMagic
   # MimeMagic version string
   # @api public
-  VERSION = '0.4.3'
+  VERSION = '0.5.0'
 end

--- a/lib/mimemagic/version.rb
+++ b/lib/mimemagic/version.rb
@@ -1,5 +1,5 @@
 class MimeMagic
   # MimeMagic version string
   # @api public
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/lib/mimemagic/version.rb
+++ b/lib/mimemagic/version.rb
@@ -1,5 +1,5 @@
 class MimeMagic
   # MimeMagic version string
   # @api public
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/lib/mimemagic/version.rb
+++ b/lib/mimemagic/version.rb
@@ -1,5 +1,5 @@
 class MimeMagic
   # MimeMagic version string
   # @api public
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -25,6 +25,8 @@ class TestMimeMagic < Minitest::Test
     assert_equal 'text/html', MimeMagic.new('text/html').type
     assert_equal 'text', MimeMagic.new('text/html').mediatype
     assert_equal 'html', MimeMagic.new('text/html').subtype
+    # a little more robust equality test perchance
+    assert MimeMagic['TEXT/HTML'] == 'TeXT/HtML;charset=utf-8'
   end
 
   def test_have_mediatype_helpers

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -25,8 +25,12 @@ class TestMimeMagic < Minitest::Test
     assert_equal 'text/html', MimeMagic.new('text/html').type
     assert_equal 'text', MimeMagic.new('text/html').mediatype
     assert_equal 'html', MimeMagic.new('text/html').subtype
+
     # a little more robust equality test perchance
     assert MimeMagic['TEXT/HTML'] == 'TeXT/HtML;charset=utf-8'
+
+    # this was crashing because the RHS has no canonical
+    assert MimeMagic['text/html'] != 'application/x-bogus'
   end
 
   def test_have_mediatype_helpers

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -52,28 +52,37 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_recognize_extensions
-    assert true
+    assert MimeMagic.by_extension('html')
 
-    # Unknown if this test failure is expected. Commenting out for now.
+    # these resolve to application/xhtml+xml instead of text/html
+    # because of ambiguities in file extension associations; the data
+    # file associates the former since it's first.
     #
     # assert_equal 'text/html', MimeMagic.by_extension('.html').to_s
     # assert_equal 'text/html', MimeMagic.by_extension('html').to_s
     # assert_equal 'text/html', MimeMagic.by_extension(:html).to_s
-    # assert_equal 'application/x-ruby', MimeMagic.by_extension('rb').to_s
-    # assert_nil MimeMagic.by_extension('crazy')
-    # assert_nil MimeMagic.by_extension('')
+
+    assert_equal 'application/x-ruby', MimeMagic.by_extension('rb').to_s
+    assert_nil MimeMagic.by_extension('crazy')
+    assert_nil MimeMagic.by_extension('')
+    # try with duplicate
+    assert_equal 'application/octet-stream',
+      MimeMagic.by_extension('crazy', default: true).to_s
   end
 
   def test_recognize_by_a_path
-    assert true
 
-    # Unknown if this test failure is expected. Commenting out for now.
+    # once again, ambiguities.
     #
     # assert_equal 'text/html', MimeMagic.by_path('/adsjkfa/kajsdfkadsf/kajsdfjasdf.html').to_s
     # assert_equal 'text/html', MimeMagic.by_path('something.html').to_s
-    # assert_equal 'application/x-ruby', MimeMagic.by_path('wtf.rb').to_s
-    # assert_nil MimeMagic.by_path('where/am.html/crazy')
-    # assert_nil MimeMagic.by_path('')
+
+    assert_equal 'application/x-ruby', MimeMagic.by_path('wtf.rb').to_s
+    assert_nil MimeMagic.by_path('where/am.html/crazy')
+    assert_nil MimeMagic.by_path('')
+
+    assert_equal 'application/octet-stream',
+      MimeMagic.by_path('', default: true).to_s
   end
 
   def test_recognize_xlsx_as_zip_without_magic
@@ -149,6 +158,16 @@ class TestMimeMagic < Minitest::Test
     assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new 'X MAGICTEST').to_s
     assert_equal 'application/mimemagic-test', MimeMagic.by_magic(StringIO.new 'Y MAGICTEST').to_s
     assert_nil MimeMagic.by_magic(StringIO.new 'Z MAGICTEST')
+  end
+
+  def test_type_is_binary
+    assert MimeMagic.binary? 'psd'
+    refute MimeMagic.binary? 'html'
+  end
+
+  def test_fancy_constructor
+    assert_equal 'text/html', MimeMagic['text/html'].to_s
+    assert_equal 'application/pdf', MimeMagic['pdf'].to_s
   end
 
   class IOObject

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -40,7 +40,10 @@ class TestMimeMagic < Minitest::Test
 
   def test_have_hierarchy
     assert MimeMagic.new('text/html').child_of?('text/plain')
-    assert MimeMagic.new('text/x-java').child_of?('text/plain')
+    # drake-no: text/plain is an ancestor but not an immediate parent
+    refute MimeMagic.new('text/x-java').child_of?('text/plain', recurse: false)
+    # drake-yes
+    assert MimeMagic.new('text/x-java').descendant_of?('text/plain')
   end
 
   def test_have_extensions
@@ -127,7 +130,7 @@ class TestMimeMagic < Minitest::Test
     assert_equal 'application/mimemagic-test', MimeMagic.by_extension('ext2').to_s
     assert_equal 'Comment', MimeMagic.by_extension('ext2').comment
     assert_equal %w(ext1 ext2), MimeMagic.new('application/mimemagic-test').extensions
-    assert MimeMagic.new('application/mimemagic-test').child_of?('text/plain')
+    assert MimeMagic.new('application/mimemagic-test').descendant_of?('text/plain')
   end
 
   def test_process_magic


### PR DESCRIPTION
Resolves #173 and #174.

Created the following new methods:

* `.binary?` predicate will tell if the input (`IO`, string, file extension, path, type, whatever) is binary
* `#binary?` instance method likewise
* `.default_type` will return either `text/plain` or `application/octet-stream` depending on whether the input is perceived to be binary
* `#aliases` (and `.aliases`) will return the list of aliases for a given type 
* `#alias?` predicate will determine if a given type is an alias of a canonical type
* `#canonical` (and `.canonical`) will return a canonical type for a (potentially aliased) type
* `#parents` will return the immediate parent types of the given type
* `#lineage` will return the entire (flattened) inheritance hierarchy of the given type, including itself
* fancy new `MimeMagic[…]` constructor will generate from a type or file extension

Other changes:

* internal database now contains aliases and the canonical type identifier
* constructor now handles type parameters; `params` accessor
* explicit `#inspect` method shows abridged diagnostic representation
* `default:` keyword parameter on `.by_extension`, `.by_path`, `.by_magic`, `.all_by_magic` will guarantee a return value when truthy (either the result of `.default_type` for the given input or a user-supplied value)
* normalized all the documentation to YARD