### PR TITLE
Support XDG_DATA_DIRS

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -4,6 +4,7 @@ require "rake/clean"
 def locate_mime_database
   possible_paths = [
     (File.expand_path(ENV["FREEDESKTOP_MIME_TYPES_PATH"]) if ENV["FREEDESKTOP_MIME_TYPES_PATH"]),
+    *ENV.fetch("XDG_DATA_DIRS", "").split(":").map { |dir| File.join(dir, "mime/packages/freedesktop.org.xml") },
     "/usr/local/share/mime/packages/freedesktop.org.xml",
     "/opt/homebrew/share/mime/packages/freedesktop.org.xml",
     "/opt/local/share/mime/packages/freedesktop.org.xml",


### PR DESCRIPTION
This is a revival of https://github.com/mimemagicrb/mimemagic/pull/163.

Nix does not install shared-mime-info to any of the locations that are currently searched. XDG_DATA_DIRS is a somewhat-standard location to hook into. Alternatively we could discover its location via pkg-config but this avoids adding any dependencies.